### PR TITLE
Added support for Rust

### DIFF
--- a/tree-sitter-fold.el
+++ b/tree-sitter-fold.el
@@ -33,10 +33,10 @@
   '((python-mode . (function_definition class_definition)) ;
     (go-mode . (type_declaration function_declaration method_declaration))
     (ess-r-mode . (brace_list))
-    (rust-mode . (struct_item enum_item function_item impl_item
-		  match_expression mod_item macro_definition))
-    (rustic-mode . (struct_item enum_item function_item impl_item
-		    match_expression mod_item macro_definition))
+    (rust-mode . (struct_item enum_item function_item trait_item impl_item
+		  match_expression mod_item macro_definition macro_invocation))
+    (rustic-mode . (struct_item enum_item function_item trait_item impl_item
+		    match_expression mod_item macro_definition macro_invocation))
     (nix-mode . (attrset function)))
   "An alist of (mode . (list of tree-sitter-nodes considered foldable in this mode))."
   :type '(alist :key-type symbol :value-type (repeat symbol))
@@ -51,17 +51,21 @@
     (rust-mode . ((struct_item . tree-sitter-fold-range-rust)
 		  (enum_item . tree-sitter-fold-range-rust)
 		  (function_item . tree-sitter-fold-range-rust)
+		  (trait_item . tree-sitter-fold-range-rust)
 		  (impl_item . tree-sitter-fold-range-rust)
 		  (match_expression . tree-sitter-fold-range-rust)
 		  (mod_item . tree-sitter-fold-range-rust)
-		  (macro_definition . tree-sitter-fold-range-rust-macro)))
+		  (macro_definition . tree-sitter-fold-range-rust-macro)
+		  (macro_invocation . tree-sitter-fold-range-rust)))
     (rustic-mode . ((struct_item . tree-sitter-fold-range-rust)
 		    (enum_item . tree-sitter-fold-range-rust)
 		    (function_item . tree-sitter-fold-range-rust)
+		    (trait_item . tree-sitter-fold-range-rust)
 		    (impl_item . tree-sitter-fold-range-rust)
 		    (match_expression . tree-sitter-fold-range-rust)
 		    (mod_item . tree-sitter-fold-range-rust)
-		    (macro_definition . tree-sitter-fold-range-rust-macro)))
+		    (macro_definition . tree-sitter-fold-range-rust-macro)
+		    (macro_invocation . tree-sitter-fold-range-rust)))
     (go-mode . ((type_declaration . tree-sitter-fold-range-go-type-declaration)
                 (function_declaration . tree-sitter-fold-range-go-method)
                 (method_declaration . tree-sitter-fold-range-go-method))))
@@ -255,7 +259,9 @@ If the current syntax node is not foldable, do nothing."
     (cons beg end)))
 
 (defun tree-sitter-fold-range-rust (node)
-  "Return the fold range for `struct_item' NODE in Rust."
+  "Return the fold range for foldable NODE in Rust.
+Foldable node-types are `struct-item', `enum_item', `function-item',`trait_item',
+`impl_item', `mod_item', `macro_invocation' and `match_expression'."
   (let ((current_node (tsc-get-nth-child node 0))
 	(result nil))
     (while (not (eq current_node nil))
@@ -263,8 +269,9 @@ If the current syntax node is not foldable, do nothing."
 	      (eq (tsc-node-type current_node) 'ordered_first_declaration_list)
 	      (eq (tsc-node-type current_node) 'enum_variant_list)
 	      (eq (tsc-node-type current_node) 'block)
-	      ;; for impl and mod items
+	      ;; for impl, mod and trait items
 	      (eq (tsc-node-type current_node) 'declaration_list)
+	      (eq (tsc-node-type current_node) 'token_tree)
 	      ;; match block won't fold semicolon in the end, so it makes clear
 	      ;; if it is present at the end of the statement even when folded
 	      (eq (tsc-node-type current_node) 'match_block))
@@ -281,11 +288,9 @@ If the current syntax node is not foldable, do nothing."
 	(result nil)
 	(last_bracket (tsc-get-nth-child node (- children 1)))
 	(first_bracket (tsc-get-nth-child node 2)))
-    (if (and (string= (tsc-node-text first_bracket) "{")
-	     (string= (tsc-node-text last_bracket) "}"))
-	(setq result (cons
-		      (tsc-node-start-position first_bracket)
-		      (+ 1 (tsc-node-start-position last_bracket)))))
+    (setq result (cons
+		  (tsc-node-start-position first_bracket)
+		  (+ 1 (tsc-node-start-position last_bracket))))
     result))
 
 (defun tree-sitter-fold-range-r (node)


### PR DESCRIPTION
Hi,
i wrote two functions to support folding in Rust.
In particular the following _tree-sitter-node-types_ are  folded:
- ***struct_item***
- ***enum_item***
- ***function_item***
- ***impl_item***
- ***mod_item***
- ***match_expression***
  _match_ in Rust is a _ExpressionWithBlock_, it can be followed by a
  semicolon or not depending on what we want to do with its return value.
  Then semicolon is not folded to make it explicit its presence and role 
  even when then _match_ item is folded
- ***macro_definition***
  this required its own function because the nodes to match
  have a slightly different pattern in the grammar

I added two entries in _tree-sitter-foldable-node-alist_ and
_tree-sitter-fold-range-alist_ because  there are currently
(as far as i know) two major mode for rust: _rust-mode_ and
_rustic-mode_ . That is redundant but makes folding work in
both cases.

I am very new to elisp, so corrections and suggestions are welcome.
Thanks for reading and for the work on this package